### PR TITLE
Add styles and update input/fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Unit Convertor</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Happy+Monkey&family=Karla:ital,wght@0,200..800;1,200..800&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Orbitron:wght@400..900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:ital,wght@0,100..900;1,100..900&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
@@ -13,13 +19,11 @@
           Metric/Imperial Unit Conversion
         </h1>
         <input
-          type="number"
+          type="text"
           class="unit-converter__input"
           id="input-value"
           name="inputValue"
-          min="0"
-          step="any"
-          placeholder="e.g. 20"
+          placeholder="20"
           required
         />
         <button type="button" id="btn-convert" class="unit-converter__button">

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,101 @@
+/* Variable */
+
+/* Layout */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+body {
+  font-family: "Poppins", sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: #fff;
+  color: rgb(57, 50, 50);
+}
+.unit-convertor {
+  width: 680px;
+  padding: 20px;
+}
+
+.unit-covertor__form {
+  background: #6943ff;
+  color: #fff;
+  text-align: center;
+}
+
+.unit-convertor__title {
+  padding: 25px;
+  font-family: inherit;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.unit-converter__input {
+  background: transparent;
+  border: 2px solid #b295ff;
+  border-radius: 4px;
+  width: 125px;
+  display: block;
+  margin: 0px auto 20px auto;
+  padding: 10px 20px;
+  font-size: 58px;
+  font-weight: 900;
+  color: #fff;
+}
+
+.unit-converter__input:active,
+.unit-converter__input:focus {
+  outline: none;
+  box-shadow: 0 1px 2px 0px #fff;
+}
+
+.unit-converter__input::placeholder {
+  color: #fff;
+}
+
+.unit-converter__button {
+  border: none;
+  border-radius: 4px;
+  padding: 12px 24px;
+  margin-bottom: 30px;
+  color: #3d3d3d;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+/* Result Section */
+
+.unit-convertor__results {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 30px;
+  padding: 40px;
+  background-color: rgb(241, 241, 241);
+}
+
+.unit-result {
+  width: 600px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  border-radius: 5px;
+  padding: 20px;
+}
+.unit-result--title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 10px;
+  color: #5a537b;
+}
+
+.unit-result__value {
+  color: #353535;
+  font-size: 14px;
+  font-weight: 400;
+}


### PR DESCRIPTION
Add Google Fonts preconnect and stylesheet link in index.html to improve typography. Change the converter input from type="number" to type="text", remove min/step attributes, and simplify the placeholder to "20" to allow more flexible input formats. Add a new styles.css with layout and component styles for the unit converter (container, form, input, button, results and result cards).